### PR TITLE
Fix domains in python 

### DIFF
--- a/fizz2.py
+++ b/fizz2.py
@@ -3,7 +3,7 @@
 import json
 import urllib2
 
-domain = 'http://localhost:3004'
+domain = 'https://api.noopschallenge.com'
 
 def print_sep(): print('----------------------------------------------------------------------')
 

--- a/fizz3.py
+++ b/fizz3.py
@@ -4,7 +4,7 @@ import json
 import urllib.request
 import urllib.error
 
-domain = 'http://localhost:3004'
+domain = 'https://api.noopschallenge.com'
 
 def print_sep(): print('----------------------------------------------------------------------')
 


### PR DESCRIPTION
Replace localhost by the real domain `https://api.noopschallenge.com`.

Fixes #10 